### PR TITLE
Fix debug plotting without cairo

### DIFF
--- a/src/ugraph/_abc/_debug.py
+++ b/src/ugraph/_abc/_debug.py
@@ -1,6 +1,9 @@
 from collections.abc import Hashable, Sequence
 from pathlib import Path
 from typing import Any
+import warnings
+
+import plotly.graph_objects as go
 
 import igraph as ig
 
@@ -20,4 +23,31 @@ def debug_plot(
         k = graph.layout_sugiyama() if graph.is_dag() else graph.layout_auto()
 
     visual_style = {"layout": k, "bbox": (4000, 4000), "vertex_size": 3}
-    ig.plot(graph, **visual_style, **kwargs).save(file_name if file_name is not None else "debug.jpg")
+    try:
+        ig.plot(graph, **visual_style, **kwargs).save(
+            file_name if file_name is not None else "debug.jpg"
+        )
+    except AttributeError:
+        # fallback to a simple plotly based plot if cairo is unavailable
+        warnings.warn("pycairo is missing; falling back to plotly for debug plot output")
+        coords = k.coords
+        edge_x: list[float] = []
+        edge_y: list[float] = []
+        for s, t in graph.get_edgelist():
+            edge_x.extend((coords[s][0], coords[t][0], None))
+            edge_y.extend((coords[s][1], coords[t][1], None))
+
+        node_x, node_y = zip(*coords)
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=edge_x, y=edge_y, mode="lines", line={"color": "black"}))
+        fig.add_trace(
+            go.Scatter(
+                x=node_x,
+                y=node_y,
+                mode="markers+text" if with_labels else "markers",
+                text=graph.vs["name"] if with_labels else None,
+            )
+        )
+        output = Path(file_name) if file_name is not None else Path("debug.html")
+        # Avoid image export if kaleido is not installed; always write html
+        fig.write_html(str(output.with_suffix(".html")))


### PR DESCRIPTION
## Summary
- add Plotly fallback for debug plotting
- warn when pycairo is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853b12d11cc8322bdf8d8e6ad8888e6