### PR TITLE
Fix plotting test for invalid image output

### DIFF
--- a/src/test_ugraph/test_ploting.py
+++ b/src/test_ugraph/test_ploting.py
@@ -37,7 +37,9 @@ class TestUgraphPlot(unittest.TestCase):
         # test the file is created
         self.assertTrue(Path("test_plot.html").exists())
 
-        self.assertRaises(ValueError, lambda: figure.write_image("test_plot.png"))
+        with self.assertRaises(ValueError):
+            figure.write_image("test_plot.png")
+        self.assertFalse(Path("test_plot.png").exists())
 
     def test_debug_plot(self):
         network = create_example_state_railway_network()


### PR DESCRIPTION
## Summary
- use context manager for ValueError check in plotting test
- verify PNG is not generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b36229948322b078c727977ba4af