### PR TITLE
Cleanup network base class and deprecate old API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ pip install ugraph
 
 Explore usage examples in the [examples directory](https://github.com/WonJayne/ugraph/tree/main/src/usage), or start with a [minimal example](https://github.com/WonJayne/ugraph/tree/main/src/usage/minimal_example.py).
 
+### Documentation
+
+For an extended introduction and code snippets, see [docs/getting_started.md](./docs/getting_started.md).
+
 ---
 
 ### Credits

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,88 @@
+# Getting Started with `ugraph`
+
+`ugraph` extends [`igraph`](https://igraph.org/) to let you store meaning alongside your graph structure. This short guide introduces the main pieces of the library and shows how to begin creating your own networks.
+
+## Installation
+
+```bash
+pip install ugraph
+# for plotting support
+pip install ugraph[plotting]
+```
+
+## Repository Layout
+
+```
+ugraph/
+├── src/
+│   ├── ugraph/       # core library
+│   ├── usage/        # examples
+│   └── test_ugraph/  # unit tests
+```
+- **`src/ugraph`** contains the abstract base classes for nodes, links and networks.
+- **`src/usage`** offers minimal and domain-specific examples such as the `StateNetwork` demo.
+- **`src/test_ugraph`** holds the test suite which also doubles as usage samples.
+
+## Defining Custom Nodes and Links
+
+Graph elements are defined as dataclasses that derive from the abstract base classes. A minimal example:
+
+```python
+from dataclasses import dataclass
+from enum import Enum, unique
+from ugraph import NodeABC, LinkABC, MutableNetworkABC
+
+@unique
+class ExampleNodeType(Enum):
+    EXAMPLE = 0
+
+@dataclass(frozen=True, slots=True)
+class ExampleNode(NodeABC[ExampleNodeType]):
+    node_type: ExampleNodeType
+    value: int
+
+@unique
+class ExampleLinkType(Enum):
+    EXAMPLE = 0
+
+@dataclass(frozen=True, slots=True)
+class ExampleLink(LinkABC[ExampleLinkType]):
+    link_type: ExampleLinkType
+
+class ExampleNetwork(MutableNetworkABC[ExampleNode, ExampleLink, ExampleNodeType, ExampleLinkType]):
+    pass
+```
+
+You can then create nodes, add them to a network, and serialize the result:
+
+```python
+n = ExampleNetwork()
+node_a = ExampleNode(id=0, coordinates=(0, 0, 0), node_type=ExampleNodeType.EXAMPLE, value=42)
+node_b = ExampleNode(id=1, coordinates=(1, 0, 0), node_type=ExampleNodeType.EXAMPLE, value=7)
+link = ExampleLink(link_type=ExampleLinkType.EXAMPLE)
+
+n.add_nodes([node_a, node_b])
+n.add_links([((node_a.id, node_b.id), link)])
+
+n.write_json("ExampleNetwork.json")
+```
+
+## Visualization
+
+With the optional `plotting` extra you can display your graphs in 3‑D using Plotly:
+
+```python
+from ugraph.plot import add_3d_ugraph_to_figure
+import plotly.graph_objects as go
+
+fig = go.Figure()
+add_3d_ugraph_to_figure(fig, n)
+fig.show()
+```
+
+## Learning More
+
+- Browse the [`src/usage`](https://github.com/WonJayne/ugraph/tree/main/src/usage) examples for ready-to-run scripts.
+- Inspect the test suite under [`src/test_ugraph`](https://github.com/WonJayne/ugraph/tree/main/src/test_ugraph) for more advanced scenarios.
+
+`ugraph` is designed to grow with your needs—extend the base classes, validate custom topologies and serialize your data for easy sharing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ugraph"
-version = "0.78.0"
+version = "0.79.0"
 description = ""
 authors = [
     "flfuchs tdubach <flfuchs@student.ethz.ch>",
@@ -9,7 +9,7 @@ authors = [
 readme = "README.md"
 repository = "https://github.com/WonJayne/ugraph"
 homepage = "https://github.com/WonJayne/ugraph"
-documentation = "https://github.com/WonJayne/ugraph/blob/main/README.md"
+documentation = "https://github.com/WonJayne/ugraph/blob/main/docs/getting_started.md"
 keywords = ["graphs", "igraph", "typed-graphs", "visualization"]
 license = "MIT"
 

--- a/src/test_ugraph/test_plotting.py
+++ b/src/test_ugraph/test_plotting.py
@@ -1,7 +1,12 @@
 import unittest
 from pathlib import Path
 
-from ugraph.plot import ColorMap, add_3d_ugraph_to_figure
+from ugraph.plot import (
+    ColorMap,
+    add_3d_ugraph_to_figure,
+    compose_collection_of_figures_with_slider,
+    compose_with_dropdown,
+)
 from usage.create_state_network_example import create_example_state_railway_network
 from usage.state_network import StateLinkType, StateNodeType
 
@@ -10,7 +15,12 @@ class TestUgraphPlot(unittest.TestCase):
 
     def setUp(self) -> None:
         # delete the file if it exists
-        for path in (Path("test_plot.html"), Path("test_plot.png")):
+        for path in (
+            Path("test_plot.html"),
+            Path("test_plot.png"),
+            Path("test_plot_with_dropdown.html"),
+            Path("test_plot_with_slider.html"),
+        ):
             if path.exists():
                 path.unlink()
 
@@ -37,7 +47,16 @@ class TestUgraphPlot(unittest.TestCase):
         # test the file is created
         self.assertTrue(Path("test_plot.html").exists())
 
-        self.assertRaises(ValueError, lambda: figure.write_image("test_plot.png"))
+        with self.assertRaises(ValueError):
+            figure.write_image("test_plot.png")
+        self.assertFalse(Path("test_plot.png").exists())
+
+        compose_with_dropdown([figure], ["Test Plot"]).write_html("test_plot_with_dropdown.html")
+
+        compose_collection_of_figures_with_slider([figure], ["Test Plot"]).write_html("test_plot_with_slider.html")
+
+        self.assertTrue(Path("test_plot_with_dropdown.html").exists())
+        self.assertTrue(Path("test_plot_with_slider.html").exists())
 
     def test_debug_plot(self):
         network = create_example_state_railway_network()

--- a/src/ugraph/_abc/_debug.py
+++ b/src/ugraph/_abc/_debug.py
@@ -1,8 +1,10 @@
+import warnings
 from collections.abc import Hashable, Sequence
 from pathlib import Path
 from typing import Any
 
 import igraph as ig
+import plotly.graph_objects as go
 
 
 def debug_plot(
@@ -20,4 +22,29 @@ def debug_plot(
         k = graph.layout_sugiyama() if graph.is_dag() else graph.layout_auto()
 
     visual_style = {"layout": k, "bbox": (4000, 4000), "vertex_size": 3}
-    ig.plot(graph, **visual_style, **kwargs).save(file_name if file_name is not None else "debug.jpg")
+    try:
+        ig.plot(graph, **visual_style, **kwargs).save(file_name if file_name is not None else "debug.jpg")
+    except AttributeError:
+        # fallback to a simple plotly based plot if cairo is unavailable
+        warnings.warn("pycairo is missing; falling back to plotly for debug plot output")
+        coords = k.coords
+        edge_x: list[float | None] = []
+        edge_y: list[float | None] = []
+        for s, t in graph.get_edgelist():
+            edge_x.extend((coords[s][0], coords[t][0], None))
+            edge_y.extend((coords[s][1], coords[t][1], None))
+
+        node_x, node_y = zip(*coords)
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=edge_x, y=edge_y, mode="lines", line={"color": "black"}))
+        fig.add_trace(
+            go.Scatter(
+                x=node_x,
+                y=node_y,
+                mode="markers+text" if with_labels else "markers",
+                text=graph.vs["name"] if with_labels else None,
+            )
+        )
+        output = Path(file_name) if file_name is not None else Path("debug.html")
+        # Avoid image export if kaleido is not installed; always write html
+        fig.write_html(str(output.with_suffix(".html")))

--- a/src/ugraph/_abc/_mutablenetwork.py
+++ b/src/ugraph/_abc/_mutablenetwork.py
@@ -110,12 +110,10 @@ def _append_to_network(
         nodes_to_add = {node.id: node for node in network_to_append.all_nodes if node.id not in existing_node_ids}
         network_to_extend.add_nodes(nodes_to_add)
     else:
-        assert (
-            set(network_to_extend.node_ids).difference(network_to_append.node_ids) == {}
-        ), f"{set(network_to_extend.node_ids).difference(network_to_append.node_ids) == {} }"
+        assert not (overlap := set(network_to_extend.node_ids).intersection(network_to_append.node_ids)), f"{overlap=}"
 
         network_to_extend.add_nodes({node.id: node for node in network_to_append.all_nodes})
-    links_to_add = tuple(network_to_append.link_by_end_node_iterator())
+    links_to_add = tuple(network_to_append.iter_links_with_end_nodes())
     if len(links_to_add) > 0:
         network_to_extend.add_links(links_to_add)
 

--- a/src/ugraph/plot/compose_sequence.py
+++ b/src/ugraph/plot/compose_sequence.py
@@ -83,7 +83,7 @@ def compose_collection_of_figures_with_slider(
     return combined_figure
 
 
-def compose_with_dropdown(figures: list[go.Figure], titles: list[str] | None = None) -> go.Figure:
+def compose_with_dropdown(figures: Sequence[go.Figure], titles: Sequence[str] | None = None) -> go.Figure:
     base_layout = figures[0].layout
     all_traces = []
     visibility_matrix = []
@@ -112,19 +112,7 @@ def compose_with_dropdown(figures: list[go.Figure], titles: list[str] | None = N
     fig = go.Figure(data=all_traces)
     fig.update_layout(
         updatemenus=[
-            {
-                "type": "dropdown",
-                "showactive": True,
-                "x": 0.1,
-                "y": 1.15,
-                "buttons": steps,
-                "direction": "down",
-                "pad": {"r": 10, "t": 10},
-                "xanchor": "left",
-                "yanchor": "top",
-                "active": 0,
-                "title": {"text": "Select Service: "},
-            }
+            {"type": "dropdown", "showactive": True, "x": 0.1, "y": 1.15, "buttons": steps, "name": "Select Figure"}
         ],
         **base_layout.to_plotly_json(),
     )

--- a/src/ugraph/plot/plot_2d.py
+++ b/src/ugraph/plot/plot_2d.py
@@ -45,7 +45,7 @@ def _create_arrow_traces(
     color_map: ColorMap, network: ImmutableNetworkABC, nodes_by_id: dict[NodeId, NodeABC], options: PlotOptions
 ) -> list[go.Cone]:
     arrow_traces = []
-    for (s_idx, t_idx), link in network.link_by_end_node_iterator():
+    for (s_idx, t_idx), link in network.iter_links_with_end_nodes():
         s_cords, t_cords = nodes_by_id[s_idx].coordinates, nodes_by_id[t_idx].coordinates
         arrow_vector = [t_cords.x - s_cords.x, t_cords.y - s_cords.y, t_cords.z - s_cords.z]
         mid_point = [(s_cords.x + t_cords.x) * 0.5, (s_cords.y + t_cords.y) * 0.5, (s_cords.z + t_cords.z) * 0.5]
@@ -103,7 +103,7 @@ def _create_edge_traces(
     edges_by_type: dict[BaseLinkType, dict[str, list[float | str | None]]] = defaultdict(
         lambda: {_key: [] for _key in ["edge_x", "edge_y", "edge_line_name", "info"]}
     )
-    for end_node_pair, link in network.link_by_end_node_iterator():
+    for end_node_pair, link in network.iter_links_with_end_nodes():
         s_node = nodes_by_id[end_node_pair[0]]
         t_node = nodes_by_id[end_node_pair[1]]
         s_cords, t_cords = s_node.coordinates, t_node.coordinates

--- a/src/ugraph/plot/plot_3d.py
+++ b/src/ugraph/plot/plot_3d.py
@@ -45,7 +45,7 @@ def _create_arrow_traces(
     color_map: ColorMap, network: ImmutableNetworkABC, nodes_by_id: dict[NodeId, NodeABC], options: PlotOptions
 ) -> list[go.Cone]:
     arrow_traces = []
-    for (s_idx, t_idx), link in network.link_by_end_node_iterator():
+    for (s_idx, t_idx), link in network.iter_links_with_end_nodes():
         s_cords, t_cords = nodes_by_id[s_idx].coordinates, nodes_by_id[t_idx].coordinates
         arrow_vector = [t_cords.x - s_cords.x, t_cords.y - s_cords.y, t_cords.z - s_cords.z]
         mid_point = [(s_cords.x + t_cords.x) * 0.5, (s_cords.y + t_cords.y) * 0.5, (s_cords.z + t_cords.z) * 0.5]
@@ -107,7 +107,7 @@ def _create_edge_traces(
     edges_by_type: dict[BaseLinkType, dict[str, list[float | str | None]]] = defaultdict(
         lambda: {_key: [] for _key in ["edge_x", "edge_y", "edge_z", "edge_line_name", "info"]}
     )
-    for end_node_pair, link in network.link_by_end_node_iterator():
+    for end_node_pair, link in network.iter_links_with_end_nodes():
         s_node = nodes_by_id[end_node_pair[0]]
         t_node = nodes_by_id[end_node_pair[1]]
         s_cords, t_cords = s_node.coordinates, t_node.coordinates

--- a/src/usage/state_network/network.py
+++ b/src/usage/state_network/network.py
@@ -10,27 +10,27 @@ from ._utils.result import Result
 class StateNetwork(MutableNetworkABC[StateNode, StateLink, StateNodeType, StateLinkType]):
 
     def reduce_to_agent_network(self) -> "StateNetwork":
-        copied = self.shallow_copy
+        copied = self.copy()
         copied.delete_nodes_without_type(frozenset((StateNodeType.AGENT,)))
         return copied
 
     def reduce_to_resource_network(self) -> "StateNetwork":
-        copied = self.shallow_copy
+        copied = self.copy()
         copied.delete_nodes_without_type(frozenset((StateNodeType.RESOURCE,)))
         return copied
 
     def reduce_to_transition_network(self) -> "StateNetwork":
-        copied = self.shallow_copy
+        copied = self.copy()
         copied.delete_nodes_without_type(frozenset((StateNodeType.INFRASTRUCTURE,)))
         return copied
 
     def reduce_to_resource_and_infrastructure_network(self) -> "StateNetwork":
-        copied = self.shallow_copy
+        copied = self.copy()
         copied.delete_nodes_without_type(frozenset((StateNodeType.RESOURCE, StateNodeType.INFRASTRUCTURE)))
         return copied
 
     def reduce_to_infrastructure_and_agent_network(self) -> "StateNetwork":
-        copied = self.shallow_copy
+        copied = self.copy()
         copied.delete_nodes_without_type(frozenset((StateNodeType.INFRASTRUCTURE, StateNodeType.AGENT)))
         return copied
 
@@ -53,15 +53,17 @@ def _validate_network_incidence(state_network: StateNetwork) -> Result[bool, str
             return Result.from_failure(f"Infrastructure component {component} is not a DAG")
         if not component.underlying_digraph.is_simple():
             component.debug_plot(file_name=f"inconsistent_infra.png")
-            return Result.from_failure(f"Infrastructure component {component} has more than one node")
-    except_transitions = state_network.shallow_copy
+            return Result.from_failure(
+                f"Infrastructure component {component} is not simple (contains loops or multiple edges)"
+            )
+    except_transitions = state_network.copy()
     for component in except_transitions.weak_components():
         if not component.underlying_digraph.is_dag():
             component.debug_plot(file_name=f"inconsistent_transitions.png")
             return Result.from_failure(f"Component {component} is not a DAG")
         if not component.underlying_digraph.is_simple():
             component.debug_plot(file_name=f"inconsistent_transitions.png")
-            return Result.from_failure(f"Component {component} has more than one node")
+            return Result.from_failure(f"Component {component} is not simple (contains loops or multiple edges)")
     return Result.from_success(True)
 
 


### PR DESCRIPTION
## Summary
- refactor abstract base class naming (node ids vs names)
- clarify copy method as shallow
- deprecate old methods with warnings
- ensure tests work with cairo substitute
- merge latest changes from `main`

## Testing
- `black --check .`
- `isort --check-only .` *(reports skipped files)*
- `flake8`
- `mypy src` *(fails: Found 15 errors)*
- `pylint src/ugraph/_abc/_immutablenetwork.py` *(fails: Unable to import 'igraph')*
- `pytest -q` *(fails: ModuleNotFoundError for 'igraph')*

------
https://chatgpt.com/codex/tasks/task_e_6853b215dae08322bea37241777a0cab