### PR TITLE
Fix deprecated iterator usage in tests

### DIFF
--- a/src/usage/state_network/network.py
+++ b/src/usage/state_network/network.py
@@ -70,7 +70,7 @@ def _validate_network_incidence(state_network: StateNetwork) -> Result[bool, str
 def _validate_node_incidence(state_network: StateNetwork) -> Result[bool, str]:
     outgoing_links = defaultdict(list)
     incoming_links = defaultdict(list)
-    for (s, t), link in state_network.link_by_tuple_iterator():
+    for (s, t), link in state_network.iter_links_with_tuples():
         outgoing_links[s].append(link)
         incoming_links[t].append(link)
     for i, node in enumerate(state_network.all_nodes):


### PR DESCRIPTION
## Summary
- use the updated `iter_links_with_tuples()` iterator when validating node incidence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bf9ee8c08322965cfa97925cf2e7