### PR TITLE
Refactor NodeABC id

### DIFF
--- a/src/ugraph/_abc/_node.py
+++ b/src/ugraph/_abc/_node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC
 from collections.abc import Collection
 from dataclasses import dataclass
@@ -23,9 +24,15 @@ NodeT = TypeVar("NodeT", bound=BaseNodeType)
 
 @dataclass(frozen=True, slots=True)
 class NodeABC(ABC, Generic[NodeT]):
-    id: NodeId
+    node_id: NodeId
     coordinates: ThreeDCoordinates
     node_type: NodeT
+
+    @property
+    def id(self) -> NodeId:  # noqa: D401 - keep name for backwards compatibility
+        """Return ``node_id`` (deprecated)."""
+        warnings.warn("NodeABC.id is deprecated, use node_id instead", DeprecationWarning, stacklevel=2)
+        return self.node_id
 
 
 T = TypeVar("T", bound="ThreeDCoordinates")

--- a/src/ugraph/plot/plot_2d.py
+++ b/src/ugraph/plot/plot_2d.py
@@ -32,7 +32,7 @@ def add_2d_ugraph_to_figure(
 def _compute_graph_traces(
     network: ImmutableNetworkABC, color_map: ColorMap, options: PlotOptions
 ) -> list[Scatter] | list[Cone | Scatter]:
-    nodes_by_id = {node.id: node for node in network.all_nodes}
+    nodes_by_id = {node.node_id: node for node in network.all_nodes}
     base_traces = _create_edge_traces(color_map, network, nodes_by_id, options) + _create_node_traces(
         color_map, network, options
     )
@@ -76,7 +76,7 @@ def _create_node_traces(color_map: ColorMap, network: ImmutableNetworkABC, optio
         _type = node.node_type
         nodes_by_type[_type]["node_x"].append(node.coordinates.x)
         nodes_by_type[_type]["node_y"].append(node.coordinates.y)
-        nodes_by_type[_type]["node_name"].append(f"{node.id} {node.node_type.name}")
+        nodes_by_type[_type]["node_name"].append(f"{node.node_id} {node.node_type.name}")
     return [
         go.Scatter(
             x=nodes["node_x"],
@@ -110,7 +110,7 @@ def _create_edge_traces(
         _type = link.link_type
         edges_by_type[_type]["edge_x"].extend((s_cords.x, (t_cords.x + s_cords.x) * 0.5, t_cords.x, None))
         edges_by_type[_type]["edge_y"].extend((s_cords.y, (t_cords.y + s_cords.y) * 0.5, t_cords.y, None))
-        text = f"S:{s_node.id} T:{t_node.id},<br>link_type:{link.link_type}"
+        text = f"S:{s_node.node_id} T:{t_node.node_id},<br>link_type:{link.link_type}"
         edges_by_type[_type]["info"].extend((text, text, text, None))
     return [
         go.Scatter(

--- a/src/ugraph/plot/plot_3d.py
+++ b/src/ugraph/plot/plot_3d.py
@@ -32,7 +32,7 @@ def add_3d_ugraph_to_figure(
 def _compute_graph_traces(
     network: ImmutableNetworkABC, color_map: ColorMap, options: PlotOptions
 ) -> list[go.Scatter3d]:
-    nodes_by_id = {node.id: node for node in network.all_nodes}
+    nodes_by_id = {node.node_id: node for node in network.all_nodes}
     base_traces = _create_edge_traces(color_map, network, nodes_by_id, options) + _create_node_traces(
         color_map, network, options
     )
@@ -79,7 +79,7 @@ def _create_node_traces(color_map: ColorMap, network: ImmutableNetworkABC, optio
         nodes_by_type[_type]["node_z"].append(node.coordinates.z)
         nodes_by_type[_type]["node_x"].append(node.coordinates.x)
         nodes_by_type[_type]["node_y"].append(node.coordinates.y)
-        nodes_by_type[_type]["node_name"].append(f"{node.id} {node.node_type.name}")
+        nodes_by_type[_type]["node_name"].append(f"{node.node_id} {node.node_type.name}")
     return [
         go.Scatter3d(
             x=nodes["node_x"],
@@ -115,7 +115,7 @@ def _create_edge_traces(
         edges_by_type[_type]["edge_x"].extend((s_cords.x, (t_cords.x + s_cords.x) * 0.5, t_cords.x, None))
         edges_by_type[_type]["edge_y"].extend((s_cords.y, (t_cords.y + s_cords.y) * 0.5, t_cords.y, None))
         edges_by_type[_type]["edge_z"].extend((s_cords.z, (t_cords.z + s_cords.z) * 0.5, t_cords.z, None))
-        text = f"S:{s_node.id} T:{t_node.id},<br>link_type:{link.link_type}"
+        text = f"S:{s_node.node_id} T:{t_node.node_id},<br>link_type:{link.link_type}"
         edges_by_type[_type]["info"].extend((text, text, text, None))
     return [
         go.Scatter3d(

--- a/src/usage/create_state_network_example.py
+++ b/src/usage/create_state_network_example.py
@@ -31,19 +31,21 @@ def create_example_state_railway_network() -> StateNetwork:
         resource_node_id = NodeId(resource_index)
         nodes_to_add.append(
             StateNode(
-                id=forward_node_id, coordinates=ThreeDCoordinates(x=x, y=y, z=0), node_type=StateNodeType.INFRASTRUCTURE
+                node_id=forward_node_id,
+                coordinates=ThreeDCoordinates(x=x, y=y, z=0),
+                node_type=StateNodeType.INFRASTRUCTURE,
             )
         )
         nodes_to_add.append(
             StateNode(
-                id=backward_node_id,
+                node_id=backward_node_id,
                 coordinates=ThreeDCoordinates(x=x, y=y + BACKWARD_OFFSET, z=0),
                 node_type=StateNodeType.INFRASTRUCTURE,
             )
         )
         nodes_to_add.append(
             StateNode(
-                id=NodeId(resource_index),
+                node_id=NodeId(resource_index),
                 coordinates=ThreeDCoordinates(x=x, y=y, z=RESOURCE_Z),
                 node_type=StateNodeType.RESOURCE,
             )

--- a/src/usage/minimal_example.py
+++ b/src/usage/minimal_example.py
@@ -50,13 +50,13 @@ class ExampleNetwork(MutableNetworkABC[ExampleNode, ExampleLink, ExampleNodeType
 def create_example_network() -> ExampleNetwork:
     # Create two nodes and a link to show how to use the network
     node_a = ExampleNode(
-        id=NodeId("A"),
+        node_id=NodeId("A"),
         coordinates=ThreeDCoordinates(x=0, y=0, z=0),
         node_type=ExampleNodeType.EXAMPLE_NODE,
         example_value=1,
     )
     node_b = ExampleNode(
-        id=NodeId("B"),
+        node_id=NodeId("B"),
         coordinates=ThreeDCoordinates(x=100, y=-100, z=100),
         node_type=ExampleNodeType.EXAMPLE_NODE,
         example_value=2,

--- a/src/usage/state_network/node.py
+++ b/src/usage/state_network/node.py
@@ -13,4 +13,4 @@ class StateNodeType(BaseNodeType):
 class StateNode(NodeABC):
     node_type: StateNodeType
     coordinates: ThreeDCoordinates
-    id: NodeId
+    node_id: NodeId


### PR DESCRIPTION
## Summary
- rename `NodeABC.id` to `node_id`
- keep deprecated `id` property for backwards compatibility
- update network helpers and plotting code
- adjust example and state network node definitions

## Testing
- `poetry run python -m unittest discover -s src/test_ugraph` *(fails: ModuleNotFoundError: No module named 'igraph')*

------
https://chatgpt.com/codex/tasks/task_e_6853bf69172c8322adda3fc8103ea152