### PR TITLE
Fix line length in MutableNetwork

### DIFF
--- a/src/ugraph/_abc/_mutablenetwork.py
+++ b/src/ugraph/_abc/_mutablenetwork.py
@@ -86,7 +86,8 @@ class MutableNetworkABC(ImmutableNetworkABC[NodeT, LinkT, NodeTypeT, LinkTypeT],
 def _add_nodes(network: MutableNetworkABC, nodes: Mapping[NodeId, NodeT] | Collection[NodeT]) -> None:
     v_count_before = network.underlying_digraph.vcount()
     network.underlying_digraph.add_vertices(len(nodes))
-    iterator_ = nodes.items() if isinstance(nodes, Mapping) else ((node.node_id, node) for node in nodes)  # type: ignore
+    node_pairs = ((node.node_id, node) for node in nodes)
+    iterator_ = nodes.items() if isinstance(nodes, Mapping) else node_pairs  # type: ignore
     for i, (node_id, node) in enumerate(iterator_, start=v_count_before):
         network.underlying_digraph.vs[i][NODE_ATTRIBUTE_KEY] = node
         network.underlying_digraph.vs[i][VERTEX_NAME_KEY] = node_id


### PR DESCRIPTION
## Summary
- refactor node iterator creation to fit within 120 chars

## Testing
- `poetry run pylint src/ugraph/_abc/_mutablenetwork.py`

------
https://chatgpt.com/codex/tasks/task_e_6853c8c485488322807e56d9a298339f