### PR TITLE
Refactor LinkABC generic typing

### DIFF
--- a/src/ugraph/_abc/_immutablenetwork.py
+++ b/src/ugraph/_abc/_immutablenetwork.py
@@ -12,13 +12,12 @@ from typing import Any, Generic, Iterator, Literal, NewType, Type, TypeVar, Unio
 import igraph
 
 from ugraph._abc._debug import debug_plot
-from ugraph._abc._link import BaseLinkType, EndNodeIdPair, LinkABC
+from ugraph._abc._link import BaseLinkType, EndNodeIdPair, LinkABC, LinkTypeT
 from ugraph._abc._node import BaseNodeType, NodeABC, NodeId, NodeIndex
 
 NodeT = TypeVar("NodeT", bound=NodeABC)
 LinkT = TypeVar("LinkT", bound=LinkABC)
 NodeTypeT = TypeVar("NodeTypeT", bound=BaseNodeType)
-LinkTypeT = TypeVar("LinkTypeT", bound=BaseLinkType)
 Self = TypeVar("Self", bound="ImmutableNetworkABC")
 LinkIndex = NewType("LinkIndex", int)
 

--- a/src/ugraph/_abc/_link.py
+++ b/src/ugraph/_abc/_link.py
@@ -13,9 +13,9 @@ class BaseLinkType(IntEnum):
     pass
 
 
-LinkT = TypeVar("LinkT", bound="LinkABC")
+LinkTypeT = TypeVar("LinkTypeT", bound=BaseLinkType)
 
 
 @dataclass(frozen=True, slots=True)
-class LinkABC(Generic[LinkT], ABC):
-    link_type: LinkT
+class LinkABC(Generic[LinkTypeT], ABC):
+    link_type: LinkTypeT

--- a/src/ugraph/_abc/_mutablenetwork.py
+++ b/src/ugraph/_abc/_mutablenetwork.py
@@ -12,11 +12,10 @@ from ugraph._abc._immutablenetwork import (
     ImmutableNetworkABC,
     LinkIndex,
     LinkT,
-    LinkTypeT,
     NodeT,
     NodeTypeT,
 )
-from ugraph._abc._link import EndNodeIdPair
+from ugraph._abc._link import EndNodeIdPair, LinkTypeT
 from ugraph._abc._node import BaseNodeType, NodeId, NodeIndex
 
 Self = TypeVar("Self", bound="MutableNetworkABC")

--- a/src/usage/state_network/link.py
+++ b/src/usage/state_network/link.py
@@ -13,5 +13,5 @@ class StateLinkType(BaseLinkType):
 
 
 @dataclass(frozen=True)
-class StateLink(LinkABC):
+class StateLink(LinkABC[StateLinkType]):
     link_type: StateLinkType


### PR DESCRIPTION
## Summary
- refine LinkABC to specify link enum type
- import new LinkTypeT in network modules
- update state network example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685901090a6083228aae675ae83c5879