### PR TITLE
Enhance debug_plot Plotly fallback with directional arrows and styling

### DIFF
--- a/src/ugraph/_abc/_debug.py
+++ b/src/ugraph/_abc/_debug.py
@@ -19,6 +19,8 @@ def debug_plot(
     with_labels: bool = True,
     file_name: str | Path | None = None,
     weights: Sequence[float] | None = None,
+    show_direction: bool = True,
+    arrow_scale: float = 0.18,
     **kwargs: dict[Hashable, Any],
 ) -> None:
     if with_labels:
@@ -32,30 +34,88 @@ def debug_plot(
     except AttributeError:
         # fallback to a simple plotly based plot if cairo is unavailable
         warnings.warn("pycairo is missing; falling back to plotly for debug plot output")
+
         coords = layout.coords
+        edge_list = graph.get_edgelist()
         edge_x = [
             coord
-            for src_idx, tgt_idx in graph.get_edgelist()
+            for src_idx, tgt_idx in edge_list
             for coord in (coords[src_idx][0], coords[tgt_idx][0], None)
         ]
         edge_y = [
             coord
-            for src_idx, tgt_idx in graph.get_edgelist()
+            for src_idx, tgt_idx in edge_list
             for coord in (coords[src_idx][1], coords[tgt_idx][1], None)
         ]
 
         node_x, node_y = zip(*coords)
         fig = go.Figure()
-        fig.add_trace(go.Scatter(x=edge_x, y=edge_y, mode="lines", name="edges", line={"color": "black"}))
+        fig.add_trace(
+            go.Scatter(
+                x=edge_x,
+                y=edge_y,
+                mode="lines",
+                name="edges",
+                line={"color": "black", "width": 1},
+                hoverinfo="skip",
+            )
+        )
         fig.add_trace(
             go.Scatter(
                 x=node_x,
                 y=node_y,
                 mode="markers+text" if with_labels else "markers",
                 text=graph.vs["name"] if with_labels else None,
+                textposition="top center",
                 name="nodes",
+                marker={"size": 8},
             )
         )
+
+        if show_direction:
+            annotations = []
+            for src_idx, tgt_idx in edge_list:
+                x0, y0 = coords[src_idx]
+                x1, y1 = coords[tgt_idx]
+
+                dx = x1 - x0
+                dy = y1 - y0
+                length = (dx**2 + dy**2) ** 0.5
+                if length == 0:
+                    continue
+
+                frac = max(0.0, 1.0 - arrow_scale / length)
+                xa = x0 + frac * dx
+                ya = y0 + frac * dy
+
+                annotations.append(
+                    dict(
+                        ax=x0,
+                        ay=y0,
+                        x=xa,
+                        y=ya,
+                        xref="x",
+                        yref="y",
+                        axref="x",
+                        ayref="y",
+                        showarrow=True,
+                        arrowhead=3,
+                        arrowsize=1.2,
+                        arrowwidth=1.2,
+                        arrowcolor="black",
+                        standoff=2,
+                    )
+                )
+
+            fig.update_layout(annotations=annotations)
+
+        fig.update_layout(
+            showlegend=False,
+            xaxis={"visible": False},
+            yaxis={"visible": False, "scaleanchor": "x", "scaleratio": 1},
+            margin={"l": 20, "r": 20, "t": 20, "b": 20},
+        )
+
         output = Path(file_name) if file_name is not None else Path("debug.html")
         # Avoid image export if kaleido is not installed; always write html
         fig.write_html(str(output.with_suffix(".html")))


### PR DESCRIPTION
### Motivation
- Improve the `debug_plot` fallback path used when pycairo is unavailable so it produces a clearer, more informative Plotly-based visualization.  
- Add optional directional arrows and small styling tweaks so debug outputs resemble the requested example and are easier to inspect.  

### Description
- Added `show_direction` and `arrow_scale` parameters to `debug_plot` to control arrow rendering and placement in the Plotly fallback.  
- Reused `edge_list` and built explicit `edge_x`/`edge_y` coordinate sequences for Plotly edge lines and adjusted edge styling with `line` width and `hoverinfo` suppression.  
- Improved node rendering with marker sizing and `textposition` when `with_labels` is enabled.  
- Implemented arrowhead annotations for directed edges with safe handling of zero-length edges and offset placement, and updated layout to hide axes, enforce equal scaling, remove legend, and tighten margins.  
- Changes applied to `src/ugraph/_abc/_debug.py` (Plotly fallback branch only) and committed.  

### Testing
- Ran `pytest -q src/test_ugraph/test_plotting.py` which failed during test collection with `ModuleNotFoundError: No module named 'igraph'` in this environment, so automated tests could not be completed here.  
- No further automated test runs were possible due to the missing `igraph` dependency during test discovery.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1839503708322a26e8d50b1434818)