### PR TITLE
Ship PEP 561 type marker with ugraph package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/WonJayne/ugraph"
 documentation = "https://github.com/WonJayne/ugraph/blob/main/docs/getting_started.md"
 keywords = ["graphs", "igraph", "typed-graphs", "visualization"]
 license = "MIT"
+include = ["src/ugraph/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/ugraph/py.typed
+++ b/src/ugraph/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 type information.


### PR DESCRIPTION
### Motivation
- Downstream projects were relying on local shadow stubs for ugraph, causing type-drift and false diagnostics, so the package needs a PEP 561 marker so type checkers treat distributed type information as authoritative.

### Description
- Add `src/ugraph/py.typed` as the PEP 561 marker file to declare the package as typed.
- Update `pyproject.toml` to include `src/ugraph/py.typed` in the published artifacts so the marker is bundled in wheels and sdists.

### Testing
- Ran `python -m mypy src/ugraph` which completed with no issues.
- Built a wheel with `poetry build -f wheel` which succeeded.
- Inspected the built wheel and confirmed it contains `ugraph/py.typed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53f7b67ac832290210b9948d75666)