### PR TITLE
Improve ugraph documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,124 @@
 # ugraph
 
-[![PyPI version](https://badge.fury.io/py/ugraph.svg)](https://badge.fury.io/py/ugraph)
+[![PyPI version](https://badge.fury.io/py/ugraph.svg)](https://pypi.org/project/ugraph/)
 [![Downloads](https://pepy.tech/badge/ugraph)](https://pepy.tech/project/ugraph)
-![black](https://img.shields.io/badge/code%20style-black-000000.svg)
-![isort](https://img.shields.io/badge/%20imports-isort-%231674b1.svg)
-![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![mypyc](https://img.shields.io/badge/mypy%20checked-100%25-brightgreen)
-![flake8](https://img.shields.io/badge/flake8%20checked-100%25-brightgreen)
-![pylint](https://img.shields.io/badge/pylint%20checked-100%25-brightgreen)
+[![Python](https://img.shields.io/pypi/pyversions/ugraph.svg)](https://pypi.org/project/ugraph/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Extend your graphs beyond structure—add meaning with `ugraph`.**
+`ugraph` is a small typed domain-model layer on top of
+[python-igraph](https://python.igraph.org/). It stores immutable Python objects as nodes and links,
+while keeping igraph's graph structure and algorithms available underneath.
 
-`ugraph` builds on [igraph](https://igraph.org/) to provide a powerful way to define and work with custom node and link types in your graphs. This package is ideal for those who need more than just graph structure—it empowers you to combine graph data with rich information via Python dataclasses, and comes with built-in support for JSON storage and 3D visualizations.
+Use it when a graph is part of your domain model—not merely an intermediate data structure—and raw
+vertex and edge attribute dictionaries would hide too much meaning.
 
-_Because your graphs aren't just for you_  
-*(igraph → ugraph)*
+In OpenBus, for example, a timetable network represents railway events as nodes and operational
+activities or constraints as directed links. Its network subclass then adds timetable-specific
+validation and transformations; `ugraph` supplies the reusable typed graph machinery.
 
----
+## What it provides
 
-### Why ugraph?
+- typed node, link, and network base classes;
+- directed graph construction, mutation, filtering, and component operations;
+- direct access to the underlying `igraph.Graph` for graph algorithms;
+- JSON round-tripping for dataclass-based networks;
+- basic debugging plots and Plotly-based 3D visualization.
 
-Graphs often represent more than their edges and nodes—they carry data, behaviors, and relationships that need to be understood in context. `ugraph` bridges this gap by enabling:
-
-- **Custom node and link classes**: Add type-safe attributes and behaviors to your graph elements.
-- **Data serialization**: Easily save and load your graphs in JSON format for persistence and sharing.
-- **3D visualization**: Render interactive, browser-based 3D visualizations in HTML using Plotly.
-
-With `ugraph`, your graphs are as **understandable** and **maintainable** as the data they represent.
-
----
-
-### Features at a Glance
-
-- **Custom Classes**: Define your nodes and links as Python dataclasses, allowing for type hints, IDE autocompletion, and type checking.
-- **Serialization**: Store and reload your networks seamlessly using JSON files.
-- **Interactive Visualization**: Generate 3D plots of your graphs in HTML for better insights and presentation.
-
----
-
-### Disclaimer
-
-`ugraph` is not intended for creating graph figures or visualizations (e.g., bar charts, scatter plots). It is a tool for working with graph data structures (nodes and links) and enhancing their usability.
-
----
-
-### Installation
-
-Install `ugraph` using pip:
+## Installation
 
 ```bash
 pip install ugraph
 ```
 
-(if you need igraph's cairo-based plotting, use `pip install ugraph[cairo]`)
+Use `pip install ugraph[cairo]` if you need igraph's Cairo-based plotting support.
 
----
+## Quick start
 
-### Quick Start
+This small event-activity network follows the same pattern as OpenBus's `TimeTableNetwork`, but
+leaves out the railway-specific detail:
 
-`ugraph` works similarly to `igraph`, with the added flexibility of custom node and link types. You can define attributes like coordinates, IDs, or any other domain-specific data in a type-safe and Pythonic way.
+```python
+from dataclasses import dataclass
 
-Explore usage examples in the [examples directory](https://github.com/WonJayne/ugraph/tree/main/src/usage), or start with a [minimal example](https://github.com/WonJayne/ugraph/tree/main/src/usage/minimal_example.py).
+from ugraph import (
+    BaseLinkType,
+    BaseNodeType,
+    EndNodeIdPair,
+    LinkABC,
+    MutableNetworkABC,
+    NodeABC,
+    NodeId,
+    ThreeDCoordinates,
+)
 
-### Documentation
 
-For an extended introduction and code snippets, see [docs/getting_started.md](./docs/getting_started.md).
+class EventType(BaseNodeType):
+    ARRIVAL = 0
+    DEPARTURE = 1
 
----
 
-### Credits
+class ActivityType(BaseLinkType):
+    DWELL = 0
 
-This project builds upon the excellent [igraph](https://igraph.org/) library. We acknowledge and thank the igraph community for their foundational work.
 
----
+@dataclass(frozen=True, slots=True)
+class Event(NodeABC[EventType]):
+    node_type: EventType
+    station: str
 
-### License
 
-See the [LICENSE](LICENSE) file for rights and limitations (MIT).
+@dataclass(frozen=True, slots=True)
+class Activity(LinkABC[ActivityType]):
+    link_type: ActivityType
+    duration_minutes: int
 
+
+class EventActivityNetwork(
+    MutableNetworkABC[Event, Activity, EventType, ActivityType]
+):
+    def is_acyclic(self) -> bool:
+        return self.underlying_digraph.is_dag()
+
+
+arrival = Event(
+    node_id=NodeId("arrival:central"),
+    coordinates=ThreeDCoordinates(0, 0, 0),
+    node_type=EventType.ARRIVAL,
+    station="Central",
+)
+departure = Event(
+    node_id=NodeId("departure:central"),
+    coordinates=ThreeDCoordinates(1, 0, 0),
+    node_type=EventType.DEPARTURE,
+    station="Central",
+)
+
+network = EventActivityNetwork.create_new(
+    nodes=(arrival, departure),
+    links=((
+        EndNodeIdPair((arrival.node_id, departure.node_id)),
+        Activity(ActivityType.DWELL, duration_minutes=2),
+    ),),
+)
+
+assert network.is_acyclic()
+assert network.n_count == 2
+assert network.l_count == 1
+```
+
+The important pattern is the separation of responsibilities: dataclasses describe domain objects,
+the network subclass holds domain operations and validation, and igraph handles generic graph
+algorithms.
+
+For serialization, mutation, visualization, and further examples, see the
+[getting-started guide](docs/getting_started.md) and the
+[example sources](https://github.com/WonJayne/ugraph/tree/main/src/usage).
+
+## Scope
+
+`ugraph` supports directed graphs with typed domain objects. It is not a general charting library or
+a replacement for igraph; it deliberately builds on igraph.
+
+## License
+
+MIT; see [LICENSE](LICENSE).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,88 +1,103 @@
-# Getting Started with `ugraph`
+# Getting started with `ugraph`
 
-`ugraph` extends [`igraph`](https://igraph.org/) to let you store meaning alongside your graph structure. This short guide introduces the main pieces of the library and shows how to begin creating your own networks.
+`ugraph` combines domain-specific Python dataclasses with a directed `igraph.Graph`. The
+[README](../README.md) contains a complete minimal example; this guide shows the operations that
+usually come next.
 
-## Installation
+## The model
 
-```bash
-pip install ugraph
-# for plotting support
-pip install ugraph[plotting]
-```
+A `ugraph` model has three parts:
 
-## Repository Layout
+1. a `NodeABC` subclass containing a stable `NodeId`, 3D coordinates, a node type, and domain data;
+2. a `LinkABC` subclass containing a link type and domain data;
+3. an `ImmutableNetworkABC` or `MutableNetworkABC` subclass containing domain-level operations and
+   validation.
 
-```
-ugraph/
-├── src/
-│   ├── ugraph/       # core library
-│   ├── usage/        # examples
-│   └── test_ugraph/  # unit tests
-```
-- **`src/ugraph`** contains the abstract base classes for nodes, links and networks.
-- **`src/usage`** offers minimal and domain-specific examples such as the `StateNetwork` demo.
-- **`src/test_ugraph`** holds the test suite which also doubles as usage samples.
+The network stores the typed objects on an underlying `igraph.Graph`. Use the `ugraph` API for typed
+access and `network.underlying_digraph` when an igraph algorithm is the clearest tool.
 
-## Defining Custom Nodes and Links
+## Constructing and inspecting a network
 
-Graph elements are defined as dataclasses that derive from the abstract base classes. A minimal example:
+Create a mutable network in one step:
 
 ```python
-from dataclasses import dataclass
-from enum import Enum, unique
-from ugraph import NodeABC, LinkABC, MutableNetworkABC
-
-@unique
-class ExampleNodeType(Enum):
-    EXAMPLE = 0
-
-@dataclass(frozen=True, slots=True)
-class ExampleNode(NodeABC[ExampleNodeType]):
-    node_type: ExampleNodeType
-    value: int
-
-@unique
-class ExampleLinkType(Enum):
-    EXAMPLE = 0
-
-@dataclass(frozen=True, slots=True)
-class ExampleLink(LinkABC[ExampleLinkType]):
-    link_type: ExampleLinkType
-
-class ExampleNetwork(MutableNetworkABC[ExampleNode, ExampleLink, ExampleNodeType, ExampleLinkType]):
-    pass
+network = EventActivityNetwork.create_new(
+    nodes=(arrival, departure),
+    links=((EndNodeIdPair((arrival.node_id, departure.node_id)), dwell),),
+)
 ```
 
-You can then create nodes, add them to a network, and serialize the result:
+The main read APIs are:
 
 ```python
-n = ExampleNetwork()
-node_a = ExampleNode(id=0, coordinates=(0, 0, 0), node_type=ExampleNodeType.EXAMPLE, value=42)
-node_b = ExampleNode(id=1, coordinates=(1, 0, 0), node_type=ExampleNodeType.EXAMPLE, value=7)
-link = ExampleLink(link_type=ExampleLinkType.EXAMPLE)
-
-n.add_nodes([node_a, node_b])
-n.add_links([((node_a.id, node_b.id), link)])
-
-n.write_json("ExampleNetwork.json")
+network.all_nodes
+network.all_links
+network.node_ids
+network.iter_links_with_end_nodes()
+network.neighbors(arrival.node_id, mode="out")
+network.weak_components()
 ```
+
+For a subset, use node IDs or indices:
+
+```python
+station_view = network.sub_network((arrival.node_id, departure.node_id))
+```
+
+`MutableNetworkABC` additionally supports `add_nodes`, `add_links`, replacement, deletion, and
+type-based filtering. `copy()` returns an independent graph structure containing the same immutable
+node and link objects.
+
+## Adding domain behavior
+
+Keep domain rules on the network subclass. This is the central pattern used by OpenBus's timetable
+networks:
+
+```python
+class EventActivityNetwork(
+    MutableNetworkABC[Event, Activity, EventType, ActivityType]
+):
+    def validate_consistency(self) -> bool:
+        if not self.underlying_digraph.is_dag():
+            raise ValueError("Event-activity network must be acyclic")
+        return True
+```
+
+This keeps generic graph mechanics in `ugraph` and domain semantics in the consuming package.
+
+## JSON round-tripping
+
+Dataclass-based networks can be written and reconstructed with their concrete node, link, and
+network types:
+
+```python
+from pathlib import Path
+
+path = Path("example.EventActivityNetwork.json")
+network.write_json(path)
+loaded = EventActivityNetwork.read_json(path)
+```
+
+The file name must end in `<NetworkClass>.json`. The involved classes must remain importable under
+the module names stored in the JSON document.
 
 ## Visualization
 
-With the optional `plotting` extra you can display your graphs in 3‑D using Plotly:
+For a quick structural debugging image:
 
 ```python
-from ugraph.plot import add_3d_ugraph_to_figure
-import plotly.graph_objects as go
-
-fig = go.Figure()
-add_3d_ugraph_to_figure(fig, n)
-fig.show()
+network.debug_plot("network.png")
 ```
 
-## Learning More
+For interactive 3D output, use the helpers under `ugraph.plot`. Node coordinates determine their
+positions; a `ColorMap` maps node and link types to colors. See
+[`src/usage/minimal_example.py`](../src/usage/minimal_example.py) for a complete plotting example.
 
-- Browse the [`src/usage`](https://github.com/WonJayne/ugraph/tree/main/src/usage) examples for ready-to-run scripts.
-- Inspect the test suite under [`src/test_ugraph`](https://github.com/WonJayne/ugraph/tree/main/src/test_ugraph) for more advanced scenarios.
+## Further examples
 
-`ugraph` is designed to grow with your needs—extend the base classes, validate custom topologies and serialize your data for easy sharing.
+- [`src/usage/minimal_example.py`](../src/usage/minimal_example.py) demonstrates construction,
+  serialization, debugging, and 3D plotting.
+- [`src/usage/state_network/`](../src/usage/state_network/) demonstrates domain-specific network
+  reductions and topology validation.
+- [`src/test_ugraph/`](../src/test_ugraph/) contains executable integration and serialization
+  examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ugraph"
 version = "0.10.5"
-description = ""
+description = "Typed domain graphs built on python-igraph"
 authors = [
     "flfuchs tdubach <flfuchs@student.ethz.ch>",
     "tdubach <thomas.dubach@ivt.baug.ethz.ch>"


### PR DESCRIPTION
## Summary

- explain `ugraph` as a typed domain-model layer on top of python-igraph
- add a compact, concrete event-activity-network example inspired by OpenBus's `TimeTableNetwork`
- clarify the division between typed domain objects, domain-specific network behavior, and igraph algorithms
- replace the broken getting-started snippets with current API usage
- add a concise package description for PyPI metadata

## User impact

New users can now understand the purpose and core modeling pattern directly from the README rendered on GitHub and PyPI. The deeper guide covers the next operations without duplicating the full introduction.

## Scope

Documentation and package metadata only. No API, implementation, version, or dependency changes.

## Validation

- `git diff --check`
- parsed all Python sources and the README quick-start snippet with `ast`
- parsed `pyproject.toml` and verified the README/description metadata
- verified all relative documentation links
- verified the GitHub branch is one commit ahead of `main` and modifies only the three intended files

The full unit suite and wheel build were not run locally because Poetry and python-igraph are absent and dependency downloads are blocked in the execution environment.